### PR TITLE
Implement weekly top commenters functionality

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -23,6 +23,15 @@ class CommentsController < ApplicationController
     end
   end
 
+  def top_commenters
+    @top_commenters = User
+      .joins(:comments)
+      .group('users.id')
+      .where('comments.created_at >= ?', 1.week.ago)
+      .order(Arel.sql('count(comments.id) desc'))
+      .limit(10)
+  end
+
   private
 
   def comment_params

--- a/app/views/comments/top_commenters.html.haml
+++ b/app/views/comments/top_commenters.html.haml
@@ -1,0 +1,7 @@
+%h1.text-center Top commenters
+%ol.commenters
+  %label{:for => "commenter.name"}> Users:
+  - @top_commenters.each do |commenter|
+    %li
+      %h4= commenter.name
+

--- a/app/views/layouts/_navigation_links.html.haml
+++ b/app/views/layouts/_navigation_links.html.haml
@@ -2,3 +2,4 @@
 %li= link_to 'Genres', genres_path
 - if user_signed_in?
   %li= link_to 'Export', export_movies_path
+  %li= link_to 'Top Commenters', top_commenters_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
 
   resources :comments, only: [:create, :destroy]
 
+  get 'top_commenters', to: 'comments#top_commenters'
+
   namespace :api do
     namespace :v1 do
       resources :movies, only: [:index, :show]

--- a/db/migrate/20181126004234_create_comments.rb
+++ b/db/migrate/20181126004234_create_comments.rb
@@ -5,6 +5,8 @@ class CreateComments < ActiveRecord::Migration[5.2]
       t.text :contents
       t.belongs_to :movie, foreign_key: true
       t.belongs_to :user, foreign_key: true
+
+      t.timestamps
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,6 +17,8 @@ ActiveRecord::Schema.define(version: 2018_11_26_004234) do
     t.text "contents"
     t.integer "movie_id"
     t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["movie_id"], name: "index_comments_on_movie_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end


### PR DESCRIPTION
In this PR I implemented weekly top commenters functionality. I had to rollback my schema by one step, because I accidentally omitted timestamps for comments in the DB and SQLite does not allow adding a column with NOT NULL field, even if the table is empty. 

In this PR feature specs should be implemented. They should check whether the order of the commenters is correct. I didn't do that because I had some issues with capybara on my local environment and I didn't have time to tackle them. 